### PR TITLE
Fix keywords in setup.py. keywords expects an iterable and we passed in ...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def main():
         namespace_packages=[b'box', b'box.test'],
         test_suite='test',
         zip_safe=False,
-        keywords='genty tests generative',
+        keywords=('genty', 'tests', 'generative'),
     )
 
 


### PR DESCRIPTION
...a string, so the keywords were g,e,n,t,y, ,t,e,s,t,s,...
