### PR TITLE
@genty_dataset is now chainable.

### DIFF
--- a/genty/genty_dataset.py
+++ b/genty/genty_dataset.py
@@ -86,7 +86,9 @@ def genty_dataset(*args, **kwargs):
         def test_some_other_function(param1, param2=None)
             ...
 
-    If
+    If the names of datasets conflict across chained genty_datasets, the
+    key&value pair from the outer (first) decorator will override the
+    data from the inner.
 
     :param args:
         Tuple of unnamed data sets.

--- a/genty/genty_dataset.py
+++ b/genty/genty_dataset.py
@@ -69,6 +69,13 @@ def genty_dataset(*args, **kwargs):
         def test_function(a, b)
             ...
 
+    Finally, datasets can be chained. Useful for example if there are
+    distinct sets of params that make sense if kept separate.
+        @genty_dataset('c1', 'c2')
+        @genty_dataset('c33', 'c44')
+        def test_some_other_function(c)
+            ...
+
     :param args:
         Tuple of unnamed data sets.
     :type args:
@@ -83,7 +90,11 @@ def genty_dataset(*args, **kwargs):
     def wrap(test_method):
         # Save the datasets in the test method. This data will be consumed
         # by the @genty decorator.
-        test_method.genty_datasets = datasets
+        if not hasattr(test_method, 'genty_datasets'):
+            test_method.genty_datasets = OrderedDict()
+
+        test_method.genty_datasets.update(datasets)
+
         return test_method
     return wrap
 

--- a/genty/genty_dataset.py
+++ b/genty/genty_dataset.py
@@ -70,11 +70,23 @@ def genty_dataset(*args, **kwargs):
             ...
 
     Finally, datasets can be chained. Useful for example if there are
-    distinct sets of params that make sense if kept separate.
-        @genty_dataset('c1', 'c2')
-        @genty_dataset('c33', 'c44')
-        def test_some_other_function(c)
+    distinct sets of params that make sense (cleaner, more readable, or
+    semantically nicer) if kept separate. A fabricated example:
+
+        @genty_dataset(
+            *([i for i in range(10)] + [(i, i) for i in range(10)])
+        )
+        def test_some_other_function(param1, param2=None)
             ...
+
+        -- vs --
+
+        @genty_dataset(*[i for i in range(10)])
+        @genty_dataset(*[(i, i) for i in range(10)])
+        def test_some_other_function(param1, param2=None)
+            ...
+
+    If
 
     :param args:
         Tuple of unnamed data sets.

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -46,6 +46,16 @@ class GentyTest(TestCase):
 
         self.assertEqual(15, SomeClass().test_undecorated())
 
+    def test_genty_decorates_test_with_args(self):
+        @genty
+        class SomeClass(object):
+            @genty_dataset((4, 7))
+            def test_decorated(self, aval, bval):
+                return aval + bval
+
+        instance = SomeClass()
+        self.assertEqual(11, getattr(instance, 'test_decorated(4, 7)')())
+
     def test_genty_replicates_method_based_on_repeat_count(self):
         @genty
         class SomeClass(object):

--- a/test/test_genty_dataset.py
+++ b/test/test_genty_dataset.py
@@ -92,6 +92,23 @@ class GentyDatasetTest(TestCase):
             some_func.genty_datasets,
         )
 
+    def test_datasets_can_be_chained(self):
+        @genty_dataset(100)
+        @genty_dataset(named_set=(99,))
+        @genty_dataset((1, 2))
+        def some_func():
+            pass
+
+        # Assert that the expected data sets are created.
+        self.assertEqual(
+            {
+                "100": (100,),
+                "named_set": (99,),
+                "1, 2": (1, 2),
+            },
+            some_func.genty_datasets,
+        )
+
     def test_unicode_name_is_safely_converted(self):
         @genty_dataset(
             ('ĥȅľľő', 'ġőőďƄŷȅ'),

--- a/test/test_genty_dataset.py
+++ b/test/test_genty_dataset.py
@@ -109,6 +109,18 @@ class GentyDatasetTest(TestCase):
             some_func.genty_datasets,
         )
 
+    def test_outer_key_value_overrides_inner_in_chained_datasets(self):
+        @genty_dataset(named_set=(99,))
+        @genty_dataset(named_set=(100,))
+        def some_func():
+            pass
+
+        # Assert that the outer value of '99' is the solitary dataset.
+        self.assertEqual(
+            {"named_set": (99,)},
+            some_func.genty_datasets,
+        )
+
     def test_unicode_name_is_safely_converted(self):
         @genty_dataset(
             ('ĥȅľľő', 'ġőőďƄŷȅ'),


### PR DESCRIPTION
Can specifiy multiple @genty_dataset decorators on a method.
Various use cases. Allows for more flexible organization of
test cases. And there's a plan for a "defered" style of
datasets, where the actual params for the test case aren't
created until the test is called, as opposed to when the test
module is imported.