### PR TITLE
Improve the fabricated test method code

### DIFF
--- a/genty/genty.py
+++ b/genty/genty.py
@@ -270,16 +270,16 @@ def _build_method_wrapper(method, dataset):
     if dataset:
         # Create the test method with the given data set.
         if isinstance(dataset, GentyArgs):
-            test_method_for_dataset = lambda *my_self: method(
-                *(my_self + dataset.args),
+            test_method_for_dataset = lambda my_self: method(
+                *((my_self,) + dataset.args),
                 **dataset.kwargs
             )
         else:
-            test_method_for_dataset = lambda *my_self: method(
-                *(my_self + dataset)
+            test_method_for_dataset = lambda my_self: method(
+                *((my_self,) + dataset)
             )
     else:
-        test_method_for_dataset = lambda *my_self: method(*my_self)
+        test_method_for_dataset = lambda my_self: method(my_self)
     return test_method_for_dataset
 
 


### PR DESCRIPTION
The fabircated test methods are these little lamdba expressions.
The param to the lamdba is just a reference to what is effectively
'self'. So replace the *args syntz with a simple 'my_self' param,
and then in the lamdba contruct the 1-tuple as needed.