### PR TITLE
Support param builder methods returning single args.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ authenticate, etc. This is supported using the ``@genty_deferred`` decorator lik
 
     @genty_dataset((1000, 100), (100, 1))
     def calculate(self, x_val, y_val):
-        # when this is called... we're been authenticated
+        # when this is called... we've been authenticated
         return self._some_function(x_val, y_val)
 
     @genty_deferred(calculate)
@@ -215,6 +215,8 @@ would run 4 tests, producing output like
 
 Notice here how the name of the helper (``calculate``) is added to the names of the 2
 executed test cases.
+
+Like ``@genty_dataset``, ``@genty_deferred`` can be chained together.
 
 Enjoy!
 

--- a/genty/genty.py
+++ b/genty/genty.py
@@ -376,16 +376,28 @@ def _build_deferred_method(method, dataset, param_factory):
         `function`
     """
     if isinstance(dataset, GentyArgs):
-        test_method = lambda my_self: method(
-            my_self,
-            *param_factory(my_self, *dataset.args, **dataset.kwargs)
-        )
+        final_args = dataset.args
+        final_kwargs = dataset.kwargs
     else:
-        test_method = lambda my_self: method(
+        final_args = dataset
+        final_kwargs = {}
+
+    def test_method_wrapper(my_self):
+        params_to_actual_test = param_factory(
             my_self,
-            *param_factory(my_self, *dataset)
+            *final_args,
+            **final_kwargs
         )
-    return test_method
+
+        if not isinstance(params_to_actual_test, (tuple, list)):
+            params_to_actual_test = (params_to_actual_test, )
+
+        return method(
+            my_self,
+            *params_to_actual_test
+        )
+
+    return test_method_wrapper
 
 
 def _build_test_method(method, dataset, param_factory=None):

--- a/genty/genty_dataset.py
+++ b/genty/genty_dataset.py
@@ -13,6 +13,18 @@ from .private import format_arg
 
 
 def genty_deferred(builder_function):
+    """Decorator defining that this test gets parameters from the given
+    build_function.
+
+    :param builder_function:
+        A callable that returns parameters that will be passed to the method
+        decorated by this decorator. If the builder_function returns a tuple
+        or list, then that will be passed as *args to the decorated method.
+        Any other return value will be treated as a single parameter, and
+        passed as such to the decorated method.
+    :type builder_function:
+        `callable`
+    """
     datasets = builder_function.genty_datasets
 
     def wrap(test_method):

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -74,4 +74,3 @@ class ExampleTests(TestCase):
         This test will be called 2 times because it's 'deferred' provider of params - the calculate helper - has
         a dataset with 2 sets of values
         """
-

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -76,6 +76,65 @@ class GentyTest(TestCase):
             )(),
         )
 
+    def test_genty_deferred_can_handle_single_parameter(self):
+        @genty
+        class SomeClass(object):
+            @genty_dataset((7, 4))
+            def my_param_factory(self, first, second):
+                return first + second
+
+            @genty_deferred(my_param_factory)
+            def test_decorated(self, sole_arg):
+                return sole_arg
+
+        instance = SomeClass()
+        self.assertEqual(
+            11,
+            getattr(
+                instance,
+                'test_decorated_{0}(7, 4)'.format('my_param_factory'),
+            )(),
+        )
+
+    def test_genty_deferred_can_be_chained(self):
+        @genty
+        class SomeClass(object):
+            @genty_dataset((7, 4))
+            def my_param_factory(self, first, second):
+                return first + second, first - second, max(first, second)
+
+            @genty_dataset(3, 5)
+            def another_param_factory(self, only):
+                return only + only, only - only, (only * only)
+
+            @genty_deferred(my_param_factory)
+            @genty_deferred(another_param_factory)
+            def test_decorated(self, value1, value2, value3):
+                return value1, value2, value3
+
+        instance = SomeClass()
+        self.assertEqual(
+            (11, 3, 7),
+            getattr(
+                instance,
+                'test_decorated_{0}(7, 4)'.format('my_param_factory'),
+            )(),
+        )
+        self.assertEqual(
+            (6, 0, 9),
+            getattr(
+                instance,
+                'test_decorated_{0}(3)'.format('another_param_factory'),
+            )(),
+        )
+        self.assertEqual(
+            (10, 0, 25),
+            getattr(
+                instance,
+                'test_decorated_{0}(5)'.format('another_param_factory'),
+            )(),
+        )
+
     def test_deferred_args_can_use_gentry_args(self):
         @genty
         class SomeClass(object):


### PR DESCRIPTION
Builder methods (that methods used by @genty_deferred) can now
return single parameters. Previous they always needed to
return a list or tuple. Thus, what used to have to be this:

   def builder(...):
      return (single_value,)

   @genty_deferred(builder)
   def test_method(...):
      ...

Can now be this:

   def builder(...):
      return single_value

   @genty_deferred(builder)
   def test_method(...):
      ...