### PR TITLE
Rename @genty_deferred to @genty_dataprovider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,7 @@ would run 4 tests, producing output like
 
 Sometimes the parameters to a test can't be determined at module load time. For example,
 some test might be based on results from some http request. And first the test needs to
-authenticate, etc. This is supported using the ``@genty_deferred`` decorator like so:
+authenticate, etc. This is supported using the ``@genty_dataprovider`` decorator like so:
 
 
 .. code-block:: python
@@ -194,7 +194,7 @@ authenticate, etc. This is supported using the ``@genty_deferred`` decorator lik
         # when this is called... we've been authenticated
         return self._some_function(x_val, y_val)
 
-    @genty_deferred(calculate)
+    @genty_dataprovider(calculate)
     def test_heavy(self, data1, data2, data3):
         ...
 
@@ -216,7 +216,7 @@ would run 4 tests, producing output like
 Notice here how the name of the helper (``calculate``) is added to the names of the 2
 executed test cases.
 
-Like ``@genty_dataset``, ``@genty_deferred`` can be chained together.
+Like ``@genty_dataset``, ``@genty_dataprovider`` can be chained together.
 
 Enjoy!
 

--- a/genty/__init__.py
+++ b/genty/__init__.py
@@ -3,6 +3,6 @@
 from __future__ import unicode_literals
 from .genty import genty
 from .genty_dataset import genty_dataset
-from .genty_dataset import genty_deferred
+from .genty_dataset import genty_dataprovider
 from .genty_repeat import genty_repeat
 from .genty_args import genty_args

--- a/genty/genty_dataset.py
+++ b/genty/genty_dataset.py
@@ -12,7 +12,7 @@ from .genty_args import GentyArgs
 from .private import format_arg
 
 
-def genty_deferred(builder_function):
+def genty_dataprovider(builder_function):
     """Decorator defining that this test gets parameters from the given
     build_function.
 
@@ -28,12 +28,12 @@ def genty_deferred(builder_function):
     datasets = builder_function.genty_datasets
 
     def wrap(test_method):
-        # Save the datasets in the test method. This data will be consumed
-        # by the @genty decorator.
-        if not hasattr(test_method, 'genty_deferred_datasets'):
-            test_method.genty_deferred_datasets = []
+        # Save the data providers in the test method. This data will be
+        # consumed by the @genty decorator.
+        if not hasattr(test_method, 'genty_dataproviders'):
+            test_method.genty_dataproviders = []
 
-        test_method.genty_deferred_datasets.append(
+        test_method.genty_dataproviders.append(
             (builder_function, datasets),
         )
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from itertools import product
 from unittest import TestCase
-from genty import genty, genty_repeat, genty_dataset, genty_args, genty_deferred
+from genty import genty, genty_repeat, genty_dataset, genty_args, genty_dataprovider
 
 
 @genty
@@ -68,9 +68,9 @@ class ExampleTests(TestCase):
     def calculate(self, x_val, y_val):
         return self._some_function(x_val, y_val)
 
-    @genty_deferred(calculate)
+    @genty_dataprovider(calculate)
     def test_heavy(self, data1, data2, data3):
         """
-        This test will be called 2 times because it's 'deferred' provider of params - the calculate helper - has
-        a dataset with 2 sets of values
+        This test will be called 2 times because the data_provider - the
+        calculate helper - has 2 datasets
         """

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 from mock import patch
 import six
-from genty import genty, genty_args, genty_dataset, genty_repeat, genty_deferred
+from genty import genty, genty_args, genty_dataset, genty_repeat, genty_dataprovider
 from genty.private import encode_non_ascii_string
 from test.base_test_case import TestCase
 
@@ -56,14 +56,14 @@ class GentyTest(TestCase):
         instance = SomeClass()
         self.assertEqual(11, getattr(instance, 'test_decorated(4, 7)')())
 
-    def test_genty_decorates_with_deferred_args(self):
+    def test_genty_decorates_with_dataprovider_args(self):
         @genty
         class SomeClass(object):
             @genty_dataset((7, 4))
             def my_param_factory(self, first, second):
                 return first + second, first - second, max(first, second)
 
-            @genty_deferred(my_param_factory)
+            @genty_dataprovider(my_param_factory)
             def test_decorated(self, summation, difference, maximum):
                 return summation, difference, maximum
 
@@ -76,14 +76,14 @@ class GentyTest(TestCase):
             )(),
         )
 
-    def test_genty_deferred_can_handle_single_parameter(self):
+    def test_genty_dataprovider_can_handle_single_parameter(self):
         @genty
         class SomeClass(object):
             @genty_dataset((7, 4))
             def my_param_factory(self, first, second):
                 return first + second
 
-            @genty_deferred(my_param_factory)
+            @genty_dataprovider(my_param_factory)
             def test_decorated(self, sole_arg):
                 return sole_arg
 
@@ -96,7 +96,7 @@ class GentyTest(TestCase):
             )(),
         )
 
-    def test_genty_deferred_can_be_chained(self):
+    def test_genty_dataprovider_can_be_chained(self):
         @genty
         class SomeClass(object):
             @genty_dataset((7, 4))
@@ -107,8 +107,8 @@ class GentyTest(TestCase):
             def another_param_factory(self, only):
                 return only + only, only - only, (only * only)
 
-            @genty_deferred(my_param_factory)
-            @genty_deferred(another_param_factory)
+            @genty_dataprovider(my_param_factory)
+            @genty_dataprovider(another_param_factory)
             def test_decorated(self, value1, value2, value3):
                 return value1, value2, value3
 
@@ -135,7 +135,7 @@ class GentyTest(TestCase):
             )(),
         )
 
-    def test_deferred_args_can_use_gentry_args(self):
+    def test_dataprovider_args_can_use_gentry_args(self):
         @genty
         class SomeClass(object):
             @genty_dataset(
@@ -144,7 +144,7 @@ class GentyTest(TestCase):
             def my_param_factory(self, first, second):
                 return first + second, first - second, max(first, second)
 
-            @genty_deferred(my_param_factory)
+            @genty_dataprovider(my_param_factory)
             def test_decorated(self, summation, difference, maximum):
                 return summation, difference, maximum
 
@@ -157,14 +157,14 @@ class GentyTest(TestCase):
             )(),
         )
 
-    def test_deferred_and_non_deferred_datasets_can_mix(self):
+    def test_dataproviders_and_datasets_can_mix(self):
         @genty
         class SomeClass(object):
             @genty_dataset((7, 4))
             def my_param_factory(self, first, second):
                 return first + second, first - second
 
-            @genty_deferred(my_param_factory)
+            @genty_dataprovider(my_param_factory)
             @genty_dataset((7, 4), (11, 3))
             def test_decorated(self, param1, param2):
                 return param1, param1, param2, param2

--- a/test/test_genty_dataset.py
+++ b/test/test_genty_dataset.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from unittest import TestCase
 
-from genty import genty_dataset, genty_deferred
+from genty import genty_dataset, genty_dataprovider
 
 
 class GentyDatasetTest(TestCase):
@@ -153,7 +153,7 @@ class GentyDatasetTest(TestCase):
             some_func.genty_datasets,
         )
 
-    def test_deferred_dataset_are_added_to_test_method(self):
+    def test_dataproviders_are_added_to_test_method(self):
         @genty_dataset(named_set_one=(99,))
         @genty_dataset(
             (5, 6),
@@ -162,7 +162,7 @@ class GentyDatasetTest(TestCase):
         def builder():
             pass
 
-        @genty_deferred(builder)
+        @genty_dataprovider(builder)
         def test_method():
             pass
 
@@ -177,24 +177,24 @@ class GentyDatasetTest(TestCase):
                     "named_set_two": (100,),
                 }
             )],
-            test_method.genty_deferred_datasets,
+            test_method.genty_dataproviders,
         )
 
-    def test_deferred_and_normal_datasets_can_mix(self):
+    def test_dataprovider_and_datasets_can_mix(self):
         @genty_dataset((5, 6))
         def builder():
             pass
 
-        @genty_deferred(builder)
+        @genty_dataprovider(builder)
         @genty_dataset((55, 66))
         def test_method():
             pass
 
-        # Assert that both deferred & non-deferred datasets are attached
+        # Assert that both dataproviders & datasets are attached
         # to the test method.
         self.assertEqual(
             [(builder, {"5, 6": (5, 6)})],
-            test_method.genty_deferred_datasets,
+            test_method.genty_dataproviders,
         )
         self.assertEqual(
             {"55, 66": (55, 66)},


### PR DESCRIPTION
Finailize on the name "genty_provider" for the new mechanism of
generating the parameters to the test_methods as the test is invoked.

There not functionliaty change here, just lots of renaming of methods
and identifiers and docstring updates.