### PR TITLE
A dataprovider need not have any datasets.

### DIFF
--- a/genty/genty.py
+++ b/genty/genty.py
@@ -129,7 +129,7 @@ def _expand_repeats(test_functions):
                     dataprovider,
                     repeat_suffix,
                 )
-        elif dataset or dataprovider:
+        else:
             yield name, func, dataset_name, dataset, dataprovider, None
 
 

--- a/genty/genty.py
+++ b/genty/genty.py
@@ -129,7 +129,7 @@ def _expand_repeats(test_functions):
                     dataprovider,
                     repeat_suffix,
                 )
-        elif dataset:
+        elif dataset or dataprovider:
             yield name, func, dataset_name, dataset, dataprovider, None
 
 
@@ -297,15 +297,14 @@ def _build_final_method_name(
     :rtype:
         `unicode`
     """
-    if not dataset_name and not repeat_suffix:
-        return method_name
-
-    suffix = ''
-
     # For tests using a dataprovider, append "_<dataprovider_name>" to
     #  the test method name
+    suffix = ''
     if dataprovider_name:
         suffix = '_{0}'.format(dataprovider_name)
+
+    if not dataset_name and not repeat_suffix:
+        return '{0}{1}'.format(method_name, suffix)
 
     # Place data_set info inside parens, as if it were a function call
     suffix = '{0}({1})'.format(suffix, dataset_name or "")
@@ -422,7 +421,7 @@ def _build_test_method(method, dataset, dataprovider=None):
     :rtype:
         `function`
     """
-    if dataset and dataprovider:
+    if dataprovider:
         test_method = _build_dataprovider_method(method, dataset, dataprovider)
     elif dataset:
         test_method = _build_dataset_method(method, dataset)

--- a/genty/genty_dataset.py
+++ b/genty/genty_dataset.py
@@ -25,7 +25,7 @@ def genty_dataprovider(builder_function):
     :type builder_function:
         `callable`
     """
-    datasets = builder_function.genty_datasets
+    datasets = getattr(builder_function, 'genty_datasets', {None: ()})
 
     def wrap(test_method):
         # Save the data providers in the test method. This data will be

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -74,3 +74,12 @@ class ExampleTests(TestCase):
         This test will be called 2 times because the data_provider - the
         calculate helper - has 2 datasets
         """
+
+    def no_dataset(self):
+        return self._some_function(100, 200)
+
+    @genty_dataprovider(no_dataset)
+    def test_dataprovider_with_no_dataset(self, data1, data2, data3):
+        """
+        Uses a dataprovider that has no datasets.
+        """

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -96,6 +96,25 @@ class GentyTest(TestCase):
             )(),
         )
 
+    def test_genty_dataprovider_doesnt_need_any_datasets(self):
+        @genty
+        class SomeClass(object):
+            def my_param_factory(self):
+                return 101
+
+            @genty_dataprovider(my_param_factory)
+            def test_decorated(self, sole_arg):
+                return sole_arg
+
+        instance = SomeClass()
+        self.assertEqual(
+            101,
+            getattr(
+                instance,
+                'test_decorated_{0}'.format('my_param_factory'),
+            )(),
+        )
+
     def test_genty_dataprovider_can_be_chained(self):
         @genty
         class SomeClass(object):


### PR DESCRIPTION
Add support for dataproviders that aren't parametrized themselves (i.e.
they don't take any parameters and don't have any @genty_datasets).