### PR TITLE
Safer generated test method names.

### DIFF
--- a/genty/genty.py
+++ b/genty/genty.py
@@ -312,7 +312,7 @@ def _build_final_method_name(
         # causes that code to fail. So replace any periods with the unicode
         # middle-dot character. Yes, this change is applied independent
         # of the test runner being used... and that's fine since there is
-        # no real contract as to how the fabricated test's are named.
+        # no real contract as to how the fabricated tests are named.
         dataset_name = dataset_name.replace('.', '\xb7')
 
     # Place data_set info inside parens, as if it were a function call

--- a/genty/genty.py
+++ b/genty/genty.py
@@ -306,6 +306,15 @@ def _build_final_method_name(
     if not dataset_name and not repeat_suffix:
         return '{0}{1}'.format(method_name, suffix)
 
+    if dataset_name:
+        # Nosetest multi-processing code parses the full test name
+        # to discern package/module names. Thus any periods in the test-name
+        # causes that code to fail. So replace any periods with the unicode
+        # middle-dot character. Yes, this change is applied independent
+        # of the test runner being used... and that's fine since there is
+        # no real contract as to how the fabricated test's are named.
+        dataset_name = dataset_name.replace('.', '\xb7')
+
     # Place data_set info inside parens, as if it were a function call
     suffix = '{0}({1})'.format(suffix, dataset_name or "")
 

--- a/genty/genty.py
+++ b/genty/genty.py
@@ -11,6 +11,8 @@ import sys
 from .genty_args import GentyArgs
 from .private import encode_non_ascii_string
 
+REPLACE_FOR_PERIOD_CHAR = '\xb7'
+
 
 def genty(target_cls):
     """
@@ -313,7 +315,7 @@ def _build_final_method_name(
         # middle-dot character. Yes, this change is applied independent
         # of the test runner being used... and that's fine since there is
         # no real contract as to how the fabricated tests are named.
-        dataset_name = dataset_name.replace('.', '\xb7')
+        dataset_name = dataset_name.replace('.', REPLACE_FOR_PERIOD_CHAR)
 
     # Place data_set info inside parens, as if it were a function call
     suffix = '{0}({1})'.format(suffix, dataset_name or "")

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -12,6 +12,8 @@ from genty import genty, genty_repeat, genty_dataset, genty_args, genty_dataprov
 
 @genty
 class ExampleTests(TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         super(ExampleTests, self).setUp()
 
@@ -82,4 +84,10 @@ class ExampleTests(TestCase):
     def test_dataprovider_with_no_dataset(self, data1, data2, data3):
         """
         Uses a dataprovider that has no datasets.
+        """
+
+    @genty_dataset('127.0.0.1')
+    def test_with_period_char_in_dataset(self, arg):
+        """
+        A dataset with a '.' doesn't screw up nosetests --processes=4
         """

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -12,6 +12,9 @@ from genty import genty, genty_repeat, genty_dataset, genty_args, genty_dataprov
 
 @genty
 class ExampleTests(TestCase):
+
+    # This is set so that if nosetest's multi-processing capability is being used, the
+    # tests in this class can be split across processes.
     _multiprocess_can_split_ = True
 
     def setUp(self):

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -437,17 +437,38 @@ class GentyTest(TestCase):
     def test_genty_properly_composes_method_with_special_chars_in_dataset_name(self):
         @genty
         class SomeClass(object):
-            @genty_dataset(*r'!"#$%&\'()*.+-/:;>=<?@[\]^_`{|}~,')
+            @genty_dataset(*r'!"#$%&\'()*+-/:;>=<?@[\]^_`{|}~,')
             def test_unicode(self, _):
                 return 33
 
         instance = SomeClass()
 
-        for char in r'!"#$%&\'()*.+-/:;>=<?@[\]^_`{|}~,':
+        for char in r'!"#$%&\'()*+-/:;>=<?@[\]^_`{|}~,':
             self.assertEqual(
                 33,
                 getattr(instance, 'test_unicode({0})'.format(repr(char)))()
             )
+
+    def test_gentry_replaces_standard_period_with_middle_dot(self):
+        # The nosetest multi-processing code parses the full test name
+        # to discern package/module names. Thus any periods in the test-name
+        # causes that code to fail. This test verifies that periods are replaced
+        # with the unicode middle-dot character.
+        @genty
+        class SomeClass(object):
+            @genty_dataset('a.b.c')
+            def test_period_char(self, _):
+                return 33
+
+        instance = SomeClass()
+
+        for attr in dir(instance):
+            if attr.startswith(encode_non_ascii_string('test_period_char')):
+                self.assertNotIn(encode_non_ascii_string('.'), attr)
+                self.assertIn(encode_non_ascii_string('·'), attr)
+                break
+        else:
+            raise KeyError("failed to find the expected test")
 
     def test_genty_properly_calls_patched_methods(self):
         class PatchableClass(object):

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -6,6 +6,7 @@ import inspect
 from mock import patch
 import six
 from genty import genty, genty_args, genty_dataset, genty_repeat, genty_dataprovider
+from genty.genty import REPLACE_FOR_PERIOD_CHAR
 from genty.private import encode_non_ascii_string
 from test.base_test_case import TestCase
 
@@ -154,7 +155,7 @@ class GentyTest(TestCase):
             )(),
         )
 
-    def test_dataprovider_args_can_use_gentry_args(self):
+    def test_dataprovider_args_can_use_genty_args(self):
         @genty
         class SomeClass(object):
             @genty_dataset(
@@ -449,7 +450,7 @@ class GentyTest(TestCase):
                 getattr(instance, 'test_unicode({0})'.format(repr(char)))()
             )
 
-    def test_gentry_replaces_standard_period_with_middle_dot(self):
+    def test_genty_replaces_standard_period_with_middle_dot(self):
         # The nosetest multi-processing code parses the full test name
         # to discern package/module names. Thus any periods in the test-name
         # causes that code to fail. This test verifies that periods are replaced
@@ -464,8 +465,16 @@ class GentyTest(TestCase):
 
         for attr in dir(instance):
             if attr.startswith(encode_non_ascii_string('test_period_char')):
-                self.assertNotIn(encode_non_ascii_string('.'), attr, "didn't expect a period character")
-                self.assertIn(encode_non_ascii_string('·'), attr, "expected the middle-dot replacement character")
+                self.assertNotIn(
+                    encode_non_ascii_string('.'),
+                    attr,
+                    "didn't expect a period character",
+                )
+                self.assertIn(
+                    encode_non_ascii_string(REPLACE_FOR_PERIOD_CHAR),
+                    attr,
+                    "expected the middle-dot replacement character",
+                )
                 break
         else:
             raise KeyError("failed to find the expected test")

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -464,8 +464,8 @@ class GentyTest(TestCase):
 
         for attr in dir(instance):
             if attr.startswith(encode_non_ascii_string('test_period_char')):
-                self.assertNotIn(encode_non_ascii_string('.'), attr)
-                self.assertIn(encode_non_ascii_string('·'), attr)
+                self.assertNotIn(encode_non_ascii_string('.'), attr, "didn't expect a period character")
+                self.assertIn(encode_non_ascii_string('·'), attr, "expected the middle-dot replacement character")
                 break
         else:
             raise KeyError("failed to find the expected test")


### PR DESCRIPTION
Replace '.' with unicode middle-dot char in the method names of the
generated tests. A plain '.' would causes failure when using the nose
test runner and it's multi-process facility.

Fixes #41.