### PR TITLE
Add wheel conditional dependencies

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 #ignore=CVS
@@ -67,19 +64,12 @@ reports=no
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
 # used to format the massage information. See doc for all details
 msg-template={module}:{line}:{column}: [{msg_id}({symbol}), {obj}] {msg}
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input
@@ -178,10 +168,6 @@ ignore-mixin-members=yes
 # (useful for classes with attributes dynamically set).
 #ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -203,10 +189,6 @@ additional-builtins=
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/genty/__init__.py
+++ b/genty/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from .genty import genty
 from .genty_dataset import genty_dataset
 from .genty_dataset import genty_dataprovider

--- a/genty/genty.py
+++ b/genty/genty.py
@@ -1,15 +1,19 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import functools
 from itertools import chain
 import math
-import types
 import re
-import six
 import sys
+import types
+
+import six
+
 from .genty_args import GentyArgs
 from .private import encode_non_ascii_string
+
 
 REPLACE_FOR_PERIOD_CHAR = '\xb7'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
+from collections import defaultdict
 from os.path import dirname, join
+import sys
+
 from setuptools import setup, find_packages
-from sys import version_info
+
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -27,14 +31,26 @@ CLASSIFIERS = [
 
 def main():
     base_dir = dirname(__file__)
+    current_python_version = '{0}.{1}'.format(*sys.version_info[:2])
     requirements = ['six']
     test_requirements = []
-    if version_info[0] == 2 and version_info[1] == 6:
-        requirements.append('ordereddict')
+    extra_requirements = defaultdict(list)
+    conditional_dependencies = {
+        'ordereddict': ['2.6'],
+    }
+    for requirement, python_versions in conditional_dependencies.items():
+        for python_version in python_versions:
+            # <https://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies>
+            python_conditional = 'python_version=="{0}"'.format(python_version)
+            key = ':{0}'.format(python_conditional)
+            extra_requirements[key].append(requirement)
+            if python_version == current_python_version:
+                requirements.append(requirement)
+    if current_python_version == '2.6':
         test_requirements.append('unittest2')
     setup(
         name='genty',
-        version='1.3.0',
+        version='1.3.1',
         description='Allows you to run a test with multiple data sets',
         long_description=open(join(base_dir, 'README.rst')).read(),
         author='Box',
@@ -47,6 +63,7 @@ def main():
         keywords=('genty', 'tests', 'generative', 'unittest'),
         classifiers=CLASSIFIERS,
         install_requires=requirements,
+        extras_require=extra_requirements,
         tests_require=test_requirements,
     )
 

--- a/test/test_case_base.py
+++ b/test/test_case_base.py
@@ -2,8 +2,10 @@
 
 from __future__ import unicode_literals
 
-import six
 from unittest import TestCase as _TestCase
+
+import six
+
 if not hasattr(_TestCase, 'assertItemsEqual') and not hasattr(_TestCase, 'assertCountEqual'):
     # Python 2.6 support
     # pylint:disable=import-error

--- a/test/test_genty.py
+++ b/test/test_genty.py
@@ -29,7 +29,7 @@ class GentyTest(TestCase):
             def test_not_decorated(self):
                 return 13
 
-        self.assertEquals(13, SomeClass().test_not_decorated())
+        self.assertEqual(13, SomeClass().test_not_decorated())
 
     def test_genty_ignores_non_test_methods(self):
         @genty
@@ -37,7 +37,7 @@ class GentyTest(TestCase):
             def random_method(self):
                 return 'hi'
 
-        self.assertEquals('hi', SomeClass().random_method())
+        self.assertEqual('hi', SomeClass().random_method())
 
     def test_genty_leaves_undecorated_tests_untouched(self):
         @genty

--- a/test/test_genty_repeat.py
+++ b/test/test_genty_repeat.py
@@ -13,7 +13,7 @@ class GentyRepeatTest(TestCase):
         def some_func():
             pass
 
-        self.assertEqual(15, some_func.genty_repeat_count)
+        self.assertEqual(15, some_func.genty_repeat_count)  # pylint:disable=no-member
 
     def test_repeat_decorator_decorates_method_with_appropriate_repeat_count(self):
         class SomeClass(object):
@@ -23,7 +23,7 @@ class GentyRepeatTest(TestCase):
 
         some_instance = SomeClass()
 
-        self.assertEqual(13, some_instance.some_func.genty_repeat_count)
+        self.assertEqual(13, some_instance.some_func.genty_repeat_count)  # pylint:disable=no-member
 
     def test_repeat_rejects_negative_counts(self):
         with self.assertRaises(ValueError) as context:
@@ -38,4 +38,4 @@ class GentyRepeatTest(TestCase):
         def some_func():
             pass
 
-        self.assertEqual(0, some_func.genty_repeat_count)
+        self.assertEqual(0, some_func.genty_repeat_count)   # pylint:disable=no-member

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,13 @@ deps = -rrequirements-dev.txt
 commands = {envpython} setup.py test
 
 [testenv:pep8]
-commands = pep8 --ignore=E731 genty
+commands = pep8 --ignore=E731 genty setup.py
            pep8 --ignore=E501 test
 
 [testenv:pylint]
 commands =  python setup.py develop
             pylint --version
-            pylint --rcfile=.pylintrc genty
+            pylint --rcfile=.pylintrc genty setup.py
             pylint --rcfile=.pylintrc --disable=C0301 test
 
 [testenv:readme]


### PR DESCRIPTION
Bumping bugfix version to 1.3.1.

Previously, if genty was installed on Python 2.6 via a wheel
that was generated on Python 2.7+, the ordereddict dependency
would not get installed, because it was not included in the
bdist_wheel metadata.

Add the conditional dependency so that this will be installed in
the future.