### PR TITLE
Fix license meta-data, bump version to 1.3.2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -124,7 +124,7 @@ docstring-min-length=-1
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=150
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,17 @@ Release History
 Upcoming
 ++++++++
 
+1.3.2 (2016-02-23)
+++++++++++++++++++
+
+- Create wheel with license file.
+- Change the ``license`` meta-data from the full license text, to just a short
+  string, as specified in [1][2].
+
+  [1] <https://docs.python.org/3.5/distutils/setupscript.html#additional-meta-data>
+
+  [2] <https://www.python.org/dev/peps/pep-0459/#license>
+
 1.3.1 (2016-02-18)
 ++++++++++++++++++
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[metadata]
+license_file=LICENSE

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
+from codecs import open   # pylint:disable=redefined-builtin
 from collections import defaultdict
 from os.path import dirname, join
 import sys
@@ -31,12 +32,22 @@ CLASSIFIERS = [
 
 def main():
     base_dir = dirname(__file__)
-    current_python_version = '{0}.{1}'.format(*sys.version_info[:2])
     requirements = ['six']
     test_requirements = []
     extra_requirements = defaultdict(list)
     conditional_dependencies = {
-        'ordereddict': ['2.6'],
+        # Newer versions of pip and wheel, which support PEP 426, allow
+        # environment markers for conditional dependencies to use operators
+        # such as `<` and `<=` [1]. However, older versions of pip and wheel
+        # only support PEP 345, which only allows operators `==` and `in` (and
+        # their negations) along with string constants [2]. To get the widest
+        # range of support, we'll only use the `==` operator, which means
+        # explicitly listing all supported Python versions that need the extra
+        # dependencies.
+        #
+        # [1] <https://www.python.org/dev/peps/pep-0426/#environment-markers>
+        # [2] <https://www.python.org/dev/peps/pep-0345/#environment-markers>
+        'ordereddict': ['2.6'],   # < 2.7
     }
     for requirement, python_versions in conditional_dependencies.items():
         for python_version in python_versions:
@@ -44,19 +55,17 @@ def main():
             python_conditional = 'python_version=="{0}"'.format(python_version)
             key = ':{0}'.format(python_conditional)
             extra_requirements[key].append(requirement)
-            if python_version == current_python_version:
-                requirements.append(requirement)
-    if current_python_version == '2.6':
+    if sys.version_info[:2] == (2, 6):
         test_requirements.append('unittest2')
     setup(
         name='genty',
-        version='1.3.1',
+        version='1.3.2',
         description='Allows you to run a test with multiple data sets',
-        long_description=open(join(base_dir, 'README.rst')).read(),
+        long_description=open(join(base_dir, 'README.rst'), encoding='utf-8').read(),
         author='Box',
         author_email='oss@box.com',
         url='https://github.com/box/genty',
-        license=open(join(base_dir, 'LICENSE')).read(),
+        license='Apache Software License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0',
         packages=find_packages(exclude=['test']),
         test_suite='test',
         zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps = -rrequirements-dev.txt
 commands = {envpython} setup.py test
 
 [testenv:pep8]
-commands = pep8 --ignore=E731 genty setup.py
+commands = pep8 --ignore=E501,E731 genty setup.py
            pep8 --ignore=E501 test
 
 [testenv:pylint]


### PR DESCRIPTION
Create wheel with license file.

Change the `license` meta-data from the full license text, to just a short string, as specified in [1][2].

Use utf-8 encoding to open README in setup.py.

[1] https://docs.python.org/3.5/distutils/setupscript.html#additional-meta-data
[2] https://www.python.org/dev/peps/pep-0459/#license
